### PR TITLE
add toJSON() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ interface UUID {
     /*  formatting (alias)  */
     tostring(type?: string): string;
 
+    /*  sensible JSON serialization  */
+    toJSON(): string;
+
     /*  importing  */
     import(arr: number[]): UUID;
 

--- a/uuid.d.ts
+++ b/uuid.d.ts
@@ -35,6 +35,9 @@ interface UUID {
     /*  formatting (alias)  */
     toString(type?: string): string;
 
+    /*  sensible JSON serialization  */
+    toJSON(): string;
+
     /*  importing  */
     import(arr: number[]): UUID;
 

--- a/uuid.js
+++ b/uuid.js
@@ -813,6 +813,11 @@
         return this.format(type);
     };
 
+    /*  API method: overrides JSON serialization with usual text representation  */
+    UUID.prototype.toJSON = function () {
+        return this.format();
+    };
+
     /*  API method: parse UUID from usual textual representation  */
     UUID.prototype.parse = function (str, type) {
         if (typeof str !== "string")

--- a/uuid.test.js
+++ b/uuid.test.js
@@ -66,6 +66,8 @@ describe("UUID base functionality", function () {
             .to.be.equal("Ew.WIfbd-xMePrOKsd[-");
         expect(new UUID().parse("Ew.WIfbd-xMePrOKsd[-", "z85").export())
             .to.be.deep.equal([0x7d,0xa7,0x82,0x84,0x2f,0x14,0x5e,0x7f,0x95,0xe1,0xba,0xaa,0x90,0x27,0xc2,0x6f]);
+        expect(JSON.stringify(new UUID("7da78284-2f14-5e7f-95e1-baaa9027c26f")))
+            .to.be.equal("\"7da78284-2f14-5e7f-95e1-baaa9027c26f\"");
     });
     it("should be able to make various UUID versions", function () {
         expect(new UUID(1).format())


### PR DESCRIPTION
This will make JSON.stringify serialize the UUID with the usual text
representation

"071d48a6-c71a-419c-b73e-c78c8e903324"

instead of the default object representation

{"0":7,"1":29,"2":72,"3":166,"4":199,"5":26,"6":65,"7":156,"8":183,"9":62,"10":199,"11":140,"12":142,"13":144,"14":51,"15":36}